### PR TITLE
PADV-1353 feat: frontend - Skillable Dashboard button - class roster

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
         "@edx/frontend-platform": "4.5.1",
         "@edx/paragon": "20.45.0",
+        "@fortawesome/fontawesome-free": "^6.5.2",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
         "@fortawesome/free-brands-svg-icons": "5.15.4",
         "@fortawesome/free-regular-svg-icons": "5.15.4",
@@ -3603,6 +3604,15 @@
       "version": "0.2.36",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
       "integrity": "sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-free": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.5.2.tgz",
+      "integrity": "sha512-hRILoInAx8GNT5IMkrtIt9blOdrqHOnPBH+k70aWUAqPZPgopb9G5EQJFpaBx/S8zp2fC+mPW349Bziuk1o28Q==",
       "hasInstallScript": true,
       "engines": {
         "node": ">=6"
@@ -28081,6 +28091,11 @@
       "version": "0.2.36",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
       "integrity": "sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg=="
+    },
+    "@fortawesome/fontawesome-free": {
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.5.2.tgz",
+      "integrity": "sha512-hRILoInAx8GNT5IMkrtIt9blOdrqHOnPBH+k70aWUAqPZPgopb9G5EQJFpaBx/S8zp2fC+mPW349Bziuk1o28Q=="
     },
     "@fortawesome/fontawesome-svg-core": {
       "version": "1.2.36",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@edx/brand": "npm:@edx/brand-openedx@1.1.0",
     "@edx/frontend-platform": "4.5.1",
     "@edx/paragon": "20.45.0",
+    "@fortawesome/fontawesome-free": "^6.5.2",
     "@fortawesome/fontawesome-svg-core": "1.2.36",
     "@fortawesome/free-brands-svg-icons": "5.15.4",
     "@fortawesome/free-regular-svg-icons": "5.15.4",

--- a/src/components/index.jsx
+++ b/src/components/index.jsx
@@ -1,10 +1,16 @@
 import React, { useState, useEffect } from 'react';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { logError } from '@edx/frontend-platform/logging';
-import { DataTable, Pagination } from '@edx/paragon';
+import {
+  DataTable,
+  Pagination,
+  Button,
+  Alert,
+} from '@edx/paragon';
 
 import './index.scss';
 
+const SKILLABLE_PLUGIN_API_URL = `${process.env.LMS_BASE_URL}/skillable_plugin/course-tab/api/v1`;
 const ENROLLMENTS_URL = `${process.env.LMS_BASE_URL}/pearson-core/api/v1/course-enrollments`;
 const COLUMNS = [
   {
@@ -18,11 +24,40 @@ const COLUMNS = [
 ];
 
 const Main = () => {
+  const [isButtonVisible, setIsButtonVisible] = useState(false);
+  const [errorMessage, setErrorMessage] = useState(null);
   const [data, setData] = useState([]);
   const [currentPage, setCurrentPage] = useState(1);
   const [pageCount, setPageCount] = useState(1);
   const courseId = window.location.pathname.split('/').filter(Boolean)[3];
   const handlePagination = (targetPage) => setCurrentPage(targetPage);
+
+  /**
+  * Handles button click event to open a URL
+  */
+  const handleButtonClick = async () => {
+    try {
+      const response = await getAuthenticatedHttpClient().post(`${SKILLABLE_PLUGIN_API_URL}/instructor-dashboard-launch/`, {
+        class_id: courseId,
+      });
+      const { url, error: responseError } = response.data;
+
+      if (url) {
+        window.open(url, '_blank', 'noopener,noreferrer');
+      } else {
+        setErrorMessage({
+          courseKey: courseId,
+          message: responseError,
+        });
+      }
+    } catch (error) {
+      logError('Error fetching URL:', error);
+      setErrorMessage({
+        courseKey: courseId,
+        message: 'An unexpected error occurred. Please try again later.',
+      });
+    }
+  };
 
   /**
   * Consumes course-enrollments API from pearson-core plugin of Devstack
@@ -43,13 +78,88 @@ const Main = () => {
     }
   };
 
+  const eventManager = (callback) => {
+    let isExecuting = false;
+    return async () => {
+      if (!isExecuting) {
+        isExecuting = true;
+        await callback();
+        setTimeout(() => {
+          isExecuting = false;
+        }, 2000); // 2 second delay
+      }
+    };
+  };
+
+  const openSkillableDashboard = eventManager(handleButtonClick);
+
+  /**
+  * Consumes isccx API to check if the course is a CCX.
+  */
+  useEffect(() => {
+    const checkCcxCourse = async () => {
+      try {
+        const response = await getAuthenticatedHttpClient().post(`${SKILLABLE_PLUGIN_API_URL}/is-ccx-course/`, {
+          class_id: courseId,
+        });
+        setIsButtonVisible(response.data.is_ccx_course);
+      } catch (error) {
+        logError('Error fetching course status:', error);
+      }
+    };
+
+    checkCcxCourse();
+  }, [courseId]);
+
   useEffect(() => {
     fetchUsersData(ENROLLMENTS_URL, currentPage);
   }, [currentPage]);
 
   return (
+
     <div>
-      <h2>Class Roster</h2>
+      <div>
+        <div className="main-header">
+          <h2>Class Roster</h2>
+          {isButtonVisible && (
+            <Button
+              className="instructor-dashboard-button"
+              variant="outline-primary"
+              onClick={openSkillableDashboard}
+            >
+              <i className="fa-solid fa-arrow-up-right-from-square" />
+              &nbsp; Go To Instructor Dashboard
+            </Button>
+          )}
+        </div>
+        {errorMessage && (
+          <div className="error-container">
+            <hr />
+            <Alert variant="danger">
+              <Alert.Heading>
+                An error occurred while launching the instructor dashboard. Please
+                find details below:
+              </Alert.Heading>
+              <ul>
+                <li>
+                  <b>Course key: </b>
+                  {errorMessage.courseKey}
+                </li>
+                <li>
+                  <b>Error message: </b>
+                  {errorMessage.message}
+                </li>
+              </ul>
+              <hr />
+              <p className="mb-0">
+                Please retry and/or contact our support team for assistance in
+                resolving this issue.
+              </p>
+            </Alert>
+            <hr />
+          </div>
+        )}
+      </div>
       <div className="tableWrapper">
         <DataTable
           itemCount={data.length}

--- a/src/components/index.scss
+++ b/src/components/index.scss
@@ -1,3 +1,22 @@
+/* index.scss */
+@import '~@fortawesome/fontawesome-free/css/all.min.css';
+
 .tableWrapper {
     padding: 10px;
+}
+
+.error-container {
+    text-align: left;
+    padding: 20px;
+}
+
+.main-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 30px;
+  }
+
+.instructor-dashboard-button {
+    margin-left: auto;
 }


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-1353

## Description
This PR adds a button that is necessary to provide instructors with an easy and quick way to access the Skillable Dashboard. 

## Dependencies

- https://github.com/Pearson-Advance/skillable-plugin/pull/42

## Changes

- [x] Creates a state handler to show/hide the button by endpoint response.
- [x] Create a handler to manage the onClick() method to retrieve the Skillable url to open it in a new template.
- [x] Add the HTM structure and style to manage the UI.

## How To Test

### - Before test, make sure that you've been downloaded the last version of skillable_plugin and go to the branch PADV-1353 if the PR https://github.com/Pearson-Advance/skillable-plugin/pull/42 has not been closed yet.

- To properly test this, please go to the following URL: http://localhost:2002/skillable_plugin/course-tab/courses/[COURSE_ID]/training_labs where you have to set the COURSE_ID in the URL with a valid course id of your devstack installation. EG: course-v1:demo+demo1+2020 now it would show a table with the users enrolled to the course. Make sure to use a CCX course id  and a non-CCX course id to test the Show/Hide button functionality.

Make sure that the button does not appears when you're selecting a CCX course id.

1. Case Skillable error:

![Peek 2024-07-08 13-54](https://github.com/Pearson-Advance/frontend-app-skillable/assets/12719909/2514ed49-377c-42e2-90c6-ec2421eacd60)


2. Case Success

![Peek 2024-07-08 14-10](https://github.com/Pearson-Advance/frontend-app-skillable/assets/12719909/6c6b9776-ec15-4a18-acac-e9676bfbfb80)



