### PR TITLE
PADV-1352 feat: frontend - Filters - class roster

### DIFF
--- a/src/components/index.scss
+++ b/src/components/index.scss
@@ -15,8 +15,40 @@
     justify-content: space-between;
     align-items: center;
     margin-top: 30px;
+    margin-left: 10px;
   }
 
 .instructor-dashboard-button {
     margin-left: auto;
+}
+
+.filterWrapper{
+    margin-left: 10px;
+    margin-top: 20px;
+}
+
+.radio-buttons {
+    display: flex;
+    align-items: center;
+    margin-left: -10px;
+
+    .form-radio {
+      margin-right: 10px;
+      margin-top: 10px;
+    }
+  }
+
+.filter-buttons{
+    display: flex;
+    align-items: center;
+    margin-right: 20px;
+}
+
+.form-custom-height input{
+    height: 50px;
+}
+
+.pgn__form-control-floating-label-text {
+    position: relative;
+    top: 3px;
 }

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,6 +1,6 @@
+@import "react-paragon-topaz/src/variables.scss";
 @import "@edx/brand/paragon/fonts.scss";
 @import "@edx/brand/paragon/variables.scss";
 @import "@edx/paragon/scss/core/core.scss";
 @import "@edx/brand/paragon/overrides.scss";
-@import "react-paragon-topaz/src/variables.scss";
 @import "react-paragon-topaz/src/styles/DataTable/DataTable.scss";


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-1352

## Description
This PR adds a button that is necessary to provide instructors with a student roster datatable filter by username and email. 

## Changes

- [x] Creates the required states for filter error messages.
- [x] Modify the fetchUsersData to receive filter as param.
- [x] Add the HTM structure and style to manage the UI.

## How To Test

- To properly test this, please go to the following URL: http://localhost:2002/skillable_plugin/course-tab/courses/[COURSE_ID]/training_labs where you have to set the COURSE_ID in the URL with a valid course id of your devstack installation. EG: course-v1:demo+demo1+2020 now it would show a table with the users enrolled to the course. Make sure you have several users enrolled to the course.
- filter as shown bellow:


![Peek 2024-07-17 12-18](https://github.com/user-attachments/assets/4ebc78d5-3677-4172-a33a-f0b346db049b)




