### PR TITLE
PADV-1358 feat: frontend - Show student name & lab name on 3rd

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Fronend App Skillable
+# Frontend App Skillable
 ## Introduction
 
 This MFE application for Skillable Project offers an extensive range of features and a user-friendly interface for any given course with the Skillable feature enabled.

--- a/src/components/AlertMessage/index.jsx
+++ b/src/components/AlertMessage/index.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Alert } from '@edx/paragon';
+import './index.scss';
+
+const AlertMessage = ({
+  variant,
+  heading,
+  message,
+  children,
+}) => (
+  <div className="error-container">
+    <Alert variant={variant}>
+      <Alert.Heading>{heading}</Alert.Heading>
+      {message && (
+        <>
+          <hr />
+          <p className="mb-0">{message}</p>
+        </>
+      )}
+      {children}
+      <hr />
+    </Alert>
+  </div>
+);
+
+AlertMessage.propTypes = {
+  variant: PropTypes.string,
+  heading: PropTypes.string.isRequired,
+  message: PropTypes.string,
+  children: PropTypes.node,
+};
+
+AlertMessage.defaultProps = {
+  variant: 'danger',
+  message: null,
+  children: null,
+};
+
+export default AlertMessage;

--- a/src/components/AlertMessage/index.scss
+++ b/src/components/AlertMessage/index.scss
@@ -1,0 +1,4 @@
+.error-container {
+    text-align: left;
+    padding: 20px 20px 0px;
+}

--- a/src/components/ClassRoster/index.jsx
+++ b/src/components/ClassRoster/index.jsx
@@ -3,13 +3,13 @@ import PropTypes from 'prop-types';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { logError } from '@edx/frontend-platform/logging';
 import {
-  Alert,
   Col,
   Form,
   Icon,
 } from '@edx/paragon';
 import { Button } from 'react-paragon-topaz';
 import { Search } from '@edx/paragon/icons';
+import AlertMessage from '../AlertMessage';
 
 import './index.scss';
 import Table from '../Table';
@@ -168,12 +168,9 @@ const ClassRoster = ({ componentNavigationHandler }) => {
         </div>
         {errorMessage && (
           <div className="error-container">
-            <hr />
-            <Alert variant="danger">
-              <Alert.Heading>
-                An error occurred while launching the instructor dashboard. Please
-                find details below:
-              </Alert.Heading>
+            <AlertMessage
+              heading="An error occurred while launching the instructor dashboard. Please find details below:"
+            >
               <ul>
                 <li>
                   <b>Course key: </b>
@@ -186,11 +183,9 @@ const ClassRoster = ({ componentNavigationHandler }) => {
               </ul>
               <hr />
               <p className="mb-0">
-                Please retry and/or contact our support team for assistance in
-                resolving this issue.
+                Please retry and/or contact our support team for assistance in resolving this issue.
               </p>
-            </Alert>
-            <hr />
+            </AlertMessage>
           </div>
         )}
       </div>

--- a/src/components/ClassRoster/index.scss
+++ b/src/components/ClassRoster/index.scss
@@ -1,10 +1,6 @@
 /* index.scss */
 @import '~@fortawesome/fontawesome-free/css/all.min.css';
 
-.error-container {
-    text-align: left;
-    padding: 20px;
-}
 
 .main-header {
     display: flex;
@@ -16,6 +12,7 @@
 
 .instructor-dashboard-button {
     margin-left: auto;
+    margin-right: 10px;
 }
 
 .filterWrapper {

--- a/src/components/LabDetails/index.jsx
+++ b/src/components/LabDetails/index.jsx
@@ -1,0 +1,107 @@
+import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
+import { logError } from '@edx/frontend-platform/logging';
+import { Breadcrumb, Spinner } from '@edx/paragon';
+import AlertMessage from '../AlertMessage';
+import './index.scss';
+import { SKILLABLE_URL } from '../../constants';
+
+const LabDetails = ({
+  componentNavigationHandler,
+  rosterStudent,
+  labData: { labInstanceId, labProfileName },
+}) => {
+  const [labDetails, setLabDetails] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState(null);
+
+  /**
+   * Handles click events on the breadcrumb links.
+   * Navigates back to the Class Roster or Lab Summary based on the clicked link's ID.
+   *
+   * @param {object} event - The click event object
+   */
+  const handleBreadcrumbClick = (event) => {
+    if (event.target.id === 'goBackToClassRoster') {
+      componentNavigationHandler(null);
+    } else if (event.target.id === 'goBackToLabSummary') {
+      componentNavigationHandler(rosterStudent);
+    }
+  };
+
+  useEffect(() => {
+    /**
+     * Fetches lab details for the given lab instance ID.
+     * Makes a POST request to the details API endpoint and updates the state with the response data.
+     * Logs any errors encountered during the request.
+     */
+    const fetchLabDetails = async () => {
+      try {
+        const response = await getAuthenticatedHttpClient().post(`${SKILLABLE_URL}/events/api/v1/details/`, {
+          labinstanceid: labInstanceId,
+        });
+        if (response.data) {
+          setLabDetails(response.data);
+        } else {
+          setErrorMessage(`No details found for this lab ${labProfileName}`);
+        }
+      } catch (error) {
+        logError(error);
+        setErrorMessage('An error occurred while fetching lab details.');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchLabDetails();
+  }, [labInstanceId]);
+
+  return (
+    <div>
+      <div className="breadcrumb-container">
+        <Breadcrumb
+          links={[
+            { label: 'Class Roster', href: '#', id: 'goBackToClassRoster' },
+            { label: 'Lab Summary', href: '#', id: 'goBackToLabSummary' },
+          ]}
+          activeLabel="Lab Details"
+          spacer={<span className="custom-spacer">/</span>}
+          clickHandler={handleBreadcrumbClick}
+        />
+      </div>
+      <div className="title-container"><h2>{labProfileName} Summary</h2></div>
+      { isLoading && (
+        <div className="spinner-container">
+          <Spinner animation="border" className="mie-3" screenReaderText="loading" />
+        </div>
+      )}
+      {!isLoading && errorMessage && (
+        <div className="error-container">
+          <AlertMessage
+            heading={errorMessage}
+            message="Please retry and/or contact our support team for assistance in
+                resolving this issue."
+          />
+        </div>
+      )}
+      {!isLoading && labDetails && (
+        // Render the lab details here
+        <div>
+          {/* Render the details of labDetails */}
+        </div>
+      )}
+    </div>
+  );
+};
+
+LabDetails.propTypes = {
+  componentNavigationHandler: PropTypes.func.isRequired,
+  rosterStudent: PropTypes.objectOf(PropTypes.string),
+  labData: PropTypes.shape({
+    labInstanceId: PropTypes.number.isRequired,
+    labProfileName: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+export default LabDetails;

--- a/src/components/LabDetails/index.scss
+++ b/src/components/LabDetails/index.scss
@@ -1,0 +1,8 @@
+/* LabDetails.scss */
+
+.spinner-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 80vh;
+  }

--- a/src/components/LabSummary/columns.jsx
+++ b/src/components/LabSummary/columns.jsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import { Hyperlink } from '@edx/paragon';
 
-const columns = () => {
+const columns = (componentNavigationHandler) => {
   /**
    * Displays the expected component when there is a click on the cell where this method is called
    *
    * @param {object} row - the given row from fetched data where the content would be accessed
    */
   const handleLabClick = (row) => {
-    // TODO: update with expected behavior
-    console.log(row.original.lab_instance_id); // eslint-disable-line no-console
+    componentNavigationHandler(null, {
+      labInstanceId: row.original.lab_instance_id,
+      labProfileName: row.original.lab_profile_name,
+    });
   };
 
   return [

--- a/src/components/LabSummary/index.jsx
+++ b/src/components/LabSummary/index.jsx
@@ -82,7 +82,7 @@ const LabSummary = ({ rosterStudent, componentNavigationHandler }) => {
       <Table
         isLoading={isLoading}
         data={labs}
-        columns={columns()}
+        columns={columns(componentNavigationHandler)}
         emptyMessage="No Labs found."
         pageCount={pageCount}
         currentPage={currentPage}

--- a/src/components/LabSummary/index.scss
+++ b/src/components/LabSummary/index.scss
@@ -13,17 +13,3 @@
 .status-na {
     color: $status-na-color;
 }
-
-.breadcrumb-container {
-    padding: 10px 20px 0px;
-}
-
-.link-muted {
-    color: #007394 !important;
-    text-decoration: underline;
-    font-weight: 700; // This makes the font more similar to the mock up
-}
-
-.title-container {
-    padding-left: 20px;
-}

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -2,35 +2,75 @@ import React, { useState } from 'react';
 
 import ClassRoster from './ClassRoster';
 import LabSummary from './LabSummary';
+import LabDetails from './LabDetails';
 
 import './Main.scss';
 
 const Main = () => {
-  const [showLabSummary, setLabSummary] = useState(false);
   const [rosterStudent, setRosterStudent] = useState(null);
+  const [showLabSummary, setShowLabSummary] = useState(false);
+  const [showLabDetails, setShowLabDetails] = useState(false);
+  const [labDetails, setLabDetails] = useState({ labInstanceId: null, labProfileName: '' });
 
   /**
    * Switch between components to be rendered,
    * When an anonymous User Id is passed, means that its Lab Summary is going to be fetched and shown
    *
    * @param {object} studentReceived - Object with the select student data
+   * @param {object | null} labDetailsReceived - Object containing labInstanceId and labProfileName (if applicable)
    */
-  const switchComponents = (studentReceived) => {
+  const switchComponents = (studentReceived, labDetailsReceived = null) => {
     if (studentReceived) {
       setRosterStudent(studentReceived);
-      setLabSummary(true);
-    } else {
-      setLabSummary(false);
+      setShowLabSummary(true);
+      setShowLabDetails(false);
+      return setShowLabSummary(true);
     }
+    if (labDetailsReceived) {
+      setLabDetails(labDetailsReceived);
+      setShowLabSummary(false);
+      setShowLabDetails(true);
+      return setShowLabDetails(true);
+    }
+    setShowLabSummary(false);
+    setShowLabDetails(false);
+    return false;
+  };
+
+  /**
+   * Renders the appropriate component based on the current state.
+   * If `showLabDetails` is true, it renders the LabDetails component.
+   * If `showLabSummary` is true, it renders the LabSummary component.
+   * Otherwise, it renders the ClassRoster component.
+   *
+   * @returns {React.Element} The component to be rendered.
+   */
+  const renderComponent = () => {
+    if (showLabDetails) {
+      return (
+        <LabDetails
+          labInstanceId={String(labDetails.labInstanceId)}
+          labProfileName={labDetails.labProfileName}
+          labData={labDetails}
+          rosterStudent={rosterStudent}
+          componentNavigationHandler={switchComponents}
+        />
+      );
+    }
+    if (showLabSummary) {
+      return (
+        <LabSummary
+          rosterStudent={rosterStudent}
+          componentNavigationHandler={switchComponents}
+        />
+      );
+    }
+    return <ClassRoster componentNavigationHandler={switchComponents} />;
   };
 
   return (
     <div className="main-container">
-      {showLabSummary ? (
-        <LabSummary rosterStudent={rosterStudent} componentNavigationHandler={switchComponents} />
-      ) : (
-        <ClassRoster componentNavigationHandler={switchComponents} />
-      )}
+      {renderComponent()}
     </div>
   );
 };

--- a/src/components/Main.scss
+++ b/src/components/Main.scss
@@ -5,3 +5,17 @@
     background-color: $app-background-color;
     padding: 10px;
 }
+
+.breadcrumb-container {
+    padding: 10px 10px 0px;
+}
+
+.link-muted {
+    color: #007394 !important;
+    text-decoration: underline;
+    font-weight: 700; // This makes the font more similar to the mock up
+}
+
+.title-container {
+    padding-left: 10px;
+}


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-1358

## Description
This PR adds the LabDetails component to the UI workflow, implements the breadcrumb and title. 

## Changes

- [x] Creates the LabDetails component.
- [x] Create AlertMessage component.
- [x] Adding Styles.
- [x] Adding componentNavigationHandler to LabSummary columns and index.
- [x]   Adding the required states to Main.

## How To Test

- To properly test this, please go to the following URL: http://localhost:2002/skillable_plugin/course-tab/courses/[COURSE_ID]/training_labs where you have to set the COURSE_ID in the URL with a valid course id of your devstack installation. EG: course-v1:demo+demo1+2020 now it would show a table with the users enrolled to the course. Next click on any user that has a lab instance, and after click on an instance as shown below:

![Peek 2024-07-25 21-26](https://github.com/user-attachments/assets/0acd33d3-51c7-4397-b440-3cea951d9fdc)

![Screenshot from 2024-07-26 11-28-22](https://github.com/user-attachments/assets/64c3861c-6d98-48bb-ba25-2d3a38a33fa3)

![Screenshot from 2024-07-26 11-28-57](https://github.com/user-attachments/assets/b461cf53-aacf-4bb3-b7e0-58bd771f44a1)





