### PR TITLE
PADV-1356 frontend - Show student Name - student lab summary

### DIFF
--- a/src/components/ClassRoster/columns.jsx
+++ b/src/components/ClassRoster/columns.jsx
@@ -8,7 +8,8 @@ const columns = (componentNavigationHandler) => {
    * @param {object} row - the given row from fetched data where the content would be accessed
    */
   const handleUsernameClick = (row) => {
-    componentNavigationHandler(row.original.anonymous_user_id);
+    const student = { user_id: row.original.anonymous_user_id, username: row.original.user };
+    componentNavigationHandler(student);
   };
 
   return [

--- a/src/components/LabSummary/index.jsx
+++ b/src/components/LabSummary/index.jsx
@@ -10,7 +10,7 @@ import { columns } from './columns';
 import { formatUnixTimestamp } from '../../helpers';
 import { SKILLABLE_URL } from '../../constants';
 
-const LabSummary = ({ anonymousUserId, componentNavigationHandler }) => {
+const LabSummary = ({ rosterStudent, componentNavigationHandler }) => {
   const [labs, setLabs] = useState([]);
   const [currentPage, setCurrentPage] = useState(1);
   const [pageCount, setPageCount] = useState(1);
@@ -32,7 +32,7 @@ const LabSummary = ({ anonymousUserId, componentNavigationHandler }) => {
     setIsLoading(true);
     try {
       const labsData = [];
-      const response = await getAuthenticatedHttpClient().post(`${apiUrl}/?page=${pageNumber}`, { userid: anonymousUserId });
+      const response = await getAuthenticatedHttpClient().post(`${apiUrl}/?page=${pageNumber}`, { userid: rosterStudent.user_id });
       const result = await response.data;
       const laboratories = result.results;
       laboratories.forEach(laboratory => {
@@ -76,6 +76,9 @@ const LabSummary = ({ anonymousUserId, componentNavigationHandler }) => {
           clickHandler={handleBreadcrumbClick}
         />
       </div>
+      <div className="title-container">
+        <h2>{ rosterStudent.username }</h2>
+      </div>
       <Table
         isLoading={isLoading}
         data={labs}
@@ -90,7 +93,7 @@ const LabSummary = ({ anonymousUserId, componentNavigationHandler }) => {
 };
 
 LabSummary.propTypes = {
-  anonymousUserId: PropTypes.string,
+  rosterStudent: PropTypes.objectOf(PropTypes.string),
   componentNavigationHandler: PropTypes.func,
 };
 

--- a/src/components/LabSummary/index.scss
+++ b/src/components/LabSummary/index.scss
@@ -23,3 +23,7 @@
     text-decoration: underline;
     font-weight: 700; // This makes the font more similar to the mock up
 }
+
+.title-container {
+    padding-left: 20px;
+}

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -7,17 +7,17 @@ import './Main.scss';
 
 const Main = () => {
   const [showLabSummary, setLabSummary] = useState(false);
-  const [anonymousUserId, setAnonymousUserId] = useState(null);
+  const [rosterStudent, setRosterStudent] = useState(null);
 
   /**
    * Switch between components to be rendered,
    * When an anonymous User Id is passed, means that its Lab Summary is going to be fetched and shown
    *
-   * @param {string} anonymousUserIdReceived - Anonymous User Id of a selected student
+   * @param {object} studentReceived - Object with the select student data
    */
-  const switchComponents = (anonymousUserIdReceived) => {
-    if (anonymousUserIdReceived) {
-      setAnonymousUserId(anonymousUserIdReceived);
+  const switchComponents = (studentReceived) => {
+    if (studentReceived) {
+      setRosterStudent(studentReceived);
       setLabSummary(true);
     } else {
       setLabSummary(false);
@@ -27,7 +27,7 @@ const Main = () => {
   return (
     <div className="main-container">
       {showLabSummary ? (
-        <LabSummary anonymousUserId={anonymousUserId} componentNavigationHandler={switchComponents} />
+        <LabSummary rosterStudent={rosterStudent} componentNavigationHandler={switchComponents} />
       ) : (
         <ClassRoster componentNavigationHandler={switchComponents} />
       )}


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-1356

## Description
This PR adds a feature to show the student username as title for the Lab Summary component.

## Changes Made

- [x] Adjust props sent to include user's username
- [x] Show student's username on lab summary component 

## How To Test

Please have your devstack environment running, run `npm start` and the MFE shall be running in port 2002 then, please go to the following URL: `http://localhost:2002/skillable_plugin/course-tab/courses/[COURSE_ID]/training_labs` where you have to set the `COURSE_ID` in the URL with a valid course id of your devstack installation. EG: `course-v1:demo+demo1+2020` now it would show a table with the users enrolled to the course and a clickable link in the Student's names.

![image](https://github.com/user-attachments/assets/5ef654cb-6ae5-40ae-878e-23cc9d129957)

Click on a user and retrieve their information, showing the lab summary table along with the username of the student.
![image](https://github.com/user-attachments/assets/faa0f0c5-354d-4198-a98c-0203b4d4c54b)
