### PR TITLE
PADV-1357 feat: frontend - Create lab summary section 3r

### DIFF
--- a/src/components/LabDetails/index.jsx
+++ b/src/components/LabDetails/index.jsx
@@ -4,6 +4,8 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { logError } from '@edx/frontend-platform/logging';
 import { Breadcrumb, Spinner } from '@edx/paragon';
 import AlertMessage from '../AlertMessage';
+import LabDetailsCard from '../LabDetailsCard';
+import { formatTime } from '../../helpers';
 import './index.scss';
 import { SKILLABLE_URL } from '../../constants';
 
@@ -86,10 +88,26 @@ const LabDetails = ({
         </div>
       )}
       {!isLoading && labDetails && (
-        // Render the lab details here
-        <div>
-          {/* Render the details of labDetails */}
+      <div className="row">
+        <div className="col-12 col-md-7">
+          <LabDetailsCard
+            details={{
+              labProfileName: labDetails.LabProfileName,
+              userFirstName: labDetails.UserFirstName,
+              userLastName: labDetails.UserLastName,
+              startTime: formatTime(labDetails.StartTime),
+              endTime: formatTime(labDetails.EndTime),
+              state: labDetails.State,
+              completionStatus: labDetails.CompletionStatus,
+              totalRunTime: labDetails.TotalRunTime,
+              examPassed: labDetails.exam_passed ? 'Yes' : 'No',
+            }}
+          />
         </div>
+        <div className="col-12 col-md-5">
+          {/* Useful for further features. */}
+        </div>
+      </div>
       )}
     </div>
   );

--- a/src/components/LabDetailsCard/index.jsx
+++ b/src/components/LabDetailsCard/index.jsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Card } from '@edx/paragon';
+import './index.scss';
+
+const LabDetailsCard = ({ details }) => {
+  const {
+    labProfileName,
+    userFirstName,
+    userLastName,
+    startTime,
+    endTime,
+    state,
+    completionStatus,
+    totalRunTime,
+    examPassed,
+  } = details;
+
+  return (
+    <div className="lab-details-card">
+      <Card className="mb-2">
+        <Card.Body>
+          <div className="lab-details">
+            <div className="lab-details-row">
+              <div className="lab-details-item">
+                <strong>LAB PROFILE NAME</strong>
+                <span>{labProfileName}</span>
+              </div>
+              <div className="lab-details-item">
+                <strong>USER FIRST NAME</strong>
+                <span>{userFirstName}</span>
+              </div>
+              <div className="lab-details-item">
+                <strong>USER LAST NAME</strong>
+                <span>{userLastName}</span>
+              </div>
+            </div>
+            <div className="lab-details-row">
+              <div className="lab-details-item">
+                <strong>START TIME</strong>
+                <span>{startTime}</span>
+              </div>
+              <div className="lab-details-item">
+                <strong>END TIME</strong>
+                <span>{endTime}</span>
+              </div>
+              <div className="lab-details-item">
+                <strong>STATE</strong>
+                <span>{state}</span>
+              </div>
+            </div>
+            <div className="lab-details-row">
+              <div className="lab-details-item">
+                <strong>COMPLETION STATUS</strong>
+                <span>{completionStatus}</span>
+              </div>
+              <div className="lab-details-item">
+                <strong>TOTAL RUN TIME</strong>
+                <span>{totalRunTime}</span>
+              </div>
+              <div className="lab-details-item">
+                <strong>EXAM PASSED</strong>
+                <span>{examPassed}</span>
+              </div>
+            </div>
+          </div>
+        </Card.Body>
+      </Card>
+    </div>
+  );
+};
+
+LabDetailsCard.defaultProps = {
+  details: {
+    labProfileName: 'N/A',
+    userFirstName: 'N/A',
+    userLastName: 'N/A',
+    startTime: 'N/A',
+    endTime: 'N/A',
+    state: 'N/A',
+    completionStatus: 'N/A',
+    totalRunTime: 'N/A',
+    examPassed: 'No',
+  },
+};
+
+LabDetailsCard.propTypes = {
+  details: PropTypes.objectOf(PropTypes.string),
+};
+
+export default LabDetailsCard;

--- a/src/components/LabDetailsCard/index.scss
+++ b/src/components/LabDetailsCard/index.scss
@@ -1,0 +1,47 @@
+.lab-details-card {
+    width: 100%;
+    margin-left: 10px;
+    margin-top: 20px;
+  }
+
+  .lab-details {
+    display: flex;
+    flex-direction: column;
+    padding: 20px 0px 20px 20px;
+  }
+
+  .lab-details-row {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 10px;
+  }
+
+  .lab-details-item {
+    flex: 1;
+    padding: 10px;
+  }
+
+  .lab-details-item strong {
+    display: block;
+    font-size: 12px;
+    color: #666;
+    font-weight: lighter;
+  }
+
+  .lab-details-item span {
+    display: block;
+    font-size: 16px;
+    color: #000;
+    font-weight: bold;
+  }
+
+  @media (max-width: 768px) {
+    .lab-details-row {
+      flex-wrap: wrap;
+    }
+
+    .lab-details-item {
+      flex: 0 0 50%;
+      padding: 10px 0;
+    }
+  }

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -43,4 +43,27 @@ const eventManager = (callback) => {
   };
 };
 
-export { eventManager, formatUnixTimestamp };
+/**
+ * Formats a timestamp string to 'MM/dd/yyyy - hh:mm a' format.
+ * If the input is null or invalid, returns 'N/A'.
+ *
+ * @param {string} time - The timestamp string to be formatted.
+ * @returns {string} - The formatted date string or 'N/A' if the input is invalid.
+ */
+const formatTime = (time) => {
+  if (!time || typeof time !== 'string') {
+    return 'N/A';
+  }
+  return new Date(parseInt(time.match(/\d+/)[0], 10))
+    .toLocaleDateString('en-US', {
+      month: '2-digit',
+      day: '2-digit',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: true,
+    })
+    .replace(',', ' -');
+};
+
+export { eventManager, formatUnixTimestamp, formatTime };


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-1357

## Description
This PR adds the LabDetailsCard component to the LabDetails UI.

## Changes

- [x] Creates the LabDetailsCard component.
- [x] Adding Styles.
- [x] Create a formatTime() function to handle the datetime input format.
- [x] Adding the LabDetailsCard component to the LabDetails view and set the arguments.

## How To Test

- To properly test this, please go to the following URL: http://localhost:2002/skillable_plugin/course-tab/courses/[COURSE_ID]/training_labs where you have to set the COURSE_ID in the URL with a valid course id of your devstack installation. EG: course-v1:demo+demo1+2020 now it would show a table with the users enrolled to the course. Next click on any user that has a lab instance, and after click on an instance and you'll see the Lab Details View with the details card.

![image](https://github.com/user-attachments/assets/522824ef-2a31-437c-882e-ace85120b849)


