### PR TITLE
PADV-1472 frontend - Create lab details Json section 3rd

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@fortawesome/react-fontawesome": "0.2.0",
         "core-js": "3.25.5",
         "jquery": "1.9.1",
+        "jsoneditor": "^10.1.0",
         "popper.js": "1.16.1",
         "prop-types": "15.8.1",
         "react": "16.14.0",
@@ -5567,6 +5568,11 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "node_modules/@sphinxxxx/color-conversion": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@sphinxxxx/color-conversion/-/color-conversion-2.2.2.tgz",
+      "integrity": "sha512-XExJS3cLqgrmNBIP3bBw6+1oQ1ksGjFh0+oClDKFYpCCqx/hlqwWO5KO/S63fzUo67SxI9dMrF0y5T/Ey7h8Zw=="
+    },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-6.0.0.tgz",
@@ -6432,6 +6438,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/ace-builds": {
+      "version": "1.35.4",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.35.4.tgz",
+      "integrity": "sha512-r0KQclhZ/uk5a4zOqRYQkJuQuu4vFMiA6VTj54Tk4nI1TUR3iEMMppZkWbNoWEgWwv4ciDloObb9Rf4V55Qgjw=="
     },
     "node_modules/acorn": {
       "version": "6.4.2",
@@ -14354,6 +14365,11 @@
         "node": ">= 4"
       }
     },
+    "node_modules/javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw=="
+    },
     "node_modules/jest": {
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest/-/jest-28.1.3.tgz",
@@ -17632,6 +17648,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/jmespath": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/jquery": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.9.1.tgz",
@@ -17742,6 +17766,11 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
+    "node_modules/json-source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/json-source-map/-/json-source-map-0.6.1.tgz",
+      "integrity": "sha512-1QoztHPsMQqhDq0hlXY5ZqcEdUzxQEIxgFkKl4WUp2pgShObl+9ovi4kRh2TfvAfxAoHOJ9vIMEqk3k4iex7tg=="
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -17761,6 +17790,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsoneditor": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/jsoneditor/-/jsoneditor-10.1.0.tgz",
+      "integrity": "sha512-s+BP/x9Rx9ukNyTjeWCvIAGTEvXwCw6l4NX4mlxXfkK87F1ZgsesHbD9SsyZDLP27dvcFgr9H/j1jy/Bzzk07Q==",
+      "dependencies": {
+        "ace-builds": "^1.35.0",
+        "ajv": "^6.12.6",
+        "javascript-natural-sort": "^0.7.1",
+        "jmespath": "^0.16.0",
+        "json-source-map": "^0.6.1",
+        "jsonrepair": "^3.8.0",
+        "mobius1-selectr": "^2.4.13",
+        "picomodal": "^3.0.0",
+        "vanilla-picker": "^2.12.3"
+      }
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -17770,6 +17815,14 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonrepair": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/jsonrepair/-/jsonrepair-3.8.0.tgz",
+      "integrity": "sha512-89lrxpwp+IEcJ6kwglF0HH3Tl17J08JEpYfXnvvjdp4zV4rjSoGu2NdQHxBs7yTOk3ETjTn9du48pBy8iBqj1w==",
+      "bin": {
+        "jsonrepair": "bin/cli.js"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -18342,6 +18395,11 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/mobius1-selectr": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/mobius1-selectr/-/mobius1-selectr-2.4.13.tgz",
+      "integrity": "sha512-Mk9qDrvU44UUL0EBhbAA1phfQZ7aMZPjwtL7wkpiBzGh8dETGqfsh50mWoX9EkjDlkONlErWXArHCKfoxVg0Bw=="
     },
     "node_modules/mozjpeg": {
       "version": "7.1.1",
@@ -19306,6 +19364,11 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/picomodal": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/picomodal/-/picomodal-3.0.0.tgz",
+      "integrity": "sha512-FoR3TDfuLlqUvcEeK5ifpKSVVns6B4BQvc8SDF6THVMuadya6LLtji0QgUDSStw0ZR2J7I6UGi5V2V23rnPWTw=="
     },
     "node_modules/pify": {
       "version": "4.0.1",
@@ -24392,6 +24455,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
       "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
+    },
+    "node_modules/vanilla-picker": {
+      "version": "2.12.3",
+      "resolved": "https://registry.npmjs.org/vanilla-picker/-/vanilla-picker-2.12.3.tgz",
+      "integrity": "sha512-qVkT1E7yMbUsB2mmJNFmaXMWE2hF8ffqzMMwe9zdAikd8u2VfnsVY2HQcOUi2F38bgbxzlJBEdS1UUhOXdF9GQ==",
+      "dependencies": {
+        "@sphinxxxx/color-conversion": "^2.2.2"
+      }
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -29566,6 +29637,11 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@sphinxxxx/color-conversion": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@sphinxxxx/color-conversion/-/color-conversion-2.2.2.tgz",
+      "integrity": "sha512-XExJS3cLqgrmNBIP3bBw6+1oQ1ksGjFh0+oClDKFYpCCqx/hlqwWO5KO/S63fzUo67SxI9dMrF0y5T/Ey7h8Zw=="
+    },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-6.0.0.tgz",
@@ -30281,6 +30357,11 @@
         "mime-types": "~2.1.34",
         "negotiator": "0.6.3"
       }
+    },
+    "ace-builds": {
+      "version": "1.35.4",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.35.4.tgz",
+      "integrity": "sha512-r0KQclhZ/uk5a4zOqRYQkJuQuu4vFMiA6VTj54Tk4nI1TUR3iEMMppZkWbNoWEgWwv4ciDloObb9Rf4V55Qgjw=="
     },
     "acorn": {
       "version": "6.4.2",
@@ -36193,6 +36274,11 @@
         "is-object": "^1.0.1"
       }
     },
+    "javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw=="
+    },
     "jest": {
       "version": "28.1.3",
       "resolved": "https://registry.npmjs.org/jest/-/jest-28.1.3.tgz",
@@ -38693,6 +38779,11 @@
         }
       }
     },
+    "jmespath": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
+    },
     "jquery": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-1.9.1.tgz",
@@ -38779,6 +38870,11 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
+    "json-source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/json-source-map/-/json-source-map-0.6.1.tgz",
+      "integrity": "sha512-1QoztHPsMQqhDq0hlXY5ZqcEdUzxQEIxgFkKl4WUp2pgShObl+9ovi4kRh2TfvAfxAoHOJ9vIMEqk3k4iex7tg=="
+    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -38792,6 +38888,22 @@
         "minimist": "^1.2.5"
       }
     },
+    "jsoneditor": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/jsoneditor/-/jsoneditor-10.1.0.tgz",
+      "integrity": "sha512-s+BP/x9Rx9ukNyTjeWCvIAGTEvXwCw6l4NX4mlxXfkK87F1ZgsesHbD9SsyZDLP27dvcFgr9H/j1jy/Bzzk07Q==",
+      "requires": {
+        "ace-builds": "^1.35.0",
+        "ajv": "^6.12.6",
+        "javascript-natural-sort": "^0.7.1",
+        "jmespath": "^0.16.0",
+        "json-source-map": "^0.6.1",
+        "jsonrepair": "^3.8.0",
+        "mobius1-selectr": "^2.4.13",
+        "picomodal": "^3.0.0",
+        "vanilla-picker": "^2.12.3"
+      }
+    },
     "jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -38800,6 +38912,11 @@
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       }
+    },
+    "jsonrepair": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/jsonrepair/-/jsonrepair-3.8.0.tgz",
+      "integrity": "sha512-89lrxpwp+IEcJ6kwglF0HH3Tl17J08JEpYfXnvvjdp4zV4rjSoGu2NdQHxBs7yTOk3ETjTn9du48pBy8iBqj1w=="
     },
     "jsx-ast-utils": {
       "version": "2.4.1",
@@ -39248,6 +39365,11 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "mobius1-selectr": {
+      "version": "2.4.13",
+      "resolved": "https://registry.npmjs.org/mobius1-selectr/-/mobius1-selectr-2.4.13.tgz",
+      "integrity": "sha512-Mk9qDrvU44UUL0EBhbAA1phfQZ7aMZPjwtL7wkpiBzGh8dETGqfsh50mWoX9EkjDlkONlErWXArHCKfoxVg0Bw=="
     },
     "mozjpeg": {
       "version": "7.1.1",
@@ -39949,6 +40071,11 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
+    },
+    "picomodal": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/picomodal/-/picomodal-3.0.0.tgz",
+      "integrity": "sha512-FoR3TDfuLlqUvcEeK5ifpKSVVns6B4BQvc8SDF6THVMuadya6LLtji0QgUDSStw0ZR2J7I6UGi5V2V23rnPWTw=="
     },
     "pify": {
       "version": "4.0.1",
@@ -43741,6 +43868,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
       "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
+    },
+    "vanilla-picker": {
+      "version": "2.12.3",
+      "resolved": "https://registry.npmjs.org/vanilla-picker/-/vanilla-picker-2.12.3.tgz",
+      "integrity": "sha512-qVkT1E7yMbUsB2mmJNFmaXMWE2hF8ffqzMMwe9zdAikd8u2VfnsVY2HQcOUi2F38bgbxzlJBEdS1UUhOXdF9GQ==",
+      "requires": {
+        "@sphinxxxx/color-conversion": "^2.2.2"
+      }
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@fortawesome/react-fontawesome": "0.2.0",
     "core-js": "3.25.5",
     "jquery": "1.9.1",
+    "jsoneditor": "^10.1.0",
     "popper.js": "1.16.1",
     "prop-types": "15.8.1",
     "react": "16.14.0",

--- a/src/components/JsonViewer/index.jsx
+++ b/src/components/JsonViewer/index.jsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useRef } from 'react';
+import {
+  array,
+  bool,
+  string,
+  shape,
+  number,
+  oneOfType,
+  PropTypes,
+} from 'prop-types';
+import JSONEditor from 'jsoneditor';
+import 'jsoneditor/dist/jsoneditor.css';
+import './index.scss';
+
+const JsonViewer = ({ labName, labData }) => {
+  const editorRef = useRef(null);
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    const options = {
+      mode: 'view', // Disable editing
+      name: labName,
+    };
+    editorRef.current = new JSONEditor(containerRef.current, options);
+    editorRef.current.set(labData);
+
+    return () => {
+      if (editorRef.current) {
+        editorRef.current.destroy();
+        editorRef.current = null;
+      }
+    };
+  }, [labData]);
+
+  return (
+    <div className="container">
+      <div ref={containerRef} />
+    </div>
+  );
+};
+
+JsonViewer.propTypes = {
+  labName: PropTypes.string.isRequired,
+  labData: PropTypes.objectOf(oneOfType([array, bool, string, number, shape({})])),
+};
+
+export default JsonViewer;

--- a/src/components/JsonViewer/index.scss
+++ b/src/components/JsonViewer/index.scss
@@ -1,0 +1,10 @@
+@import "../../variables.scss";
+
+.jsoneditor {
+    margin-top: 15px;
+    border-color: $hyperlink-color !important;
+}
+
+.jsoneditor .jsoneditor-menu {
+    background-color: $hyperlink-color !important;
+}

--- a/src/components/LabDetails/index.jsx
+++ b/src/components/LabDetails/index.jsx
@@ -8,6 +8,7 @@ import LabDetailsCard from '../LabDetailsCard';
 import { formatTime } from '../../helpers';
 import './index.scss';
 import { SKILLABLE_URL } from '../../constants';
+import JsonViewer from '../JsonViewer';
 
 const LabDetails = ({
   componentNavigationHandler,
@@ -88,24 +89,28 @@ const LabDetails = ({
         </div>
       )}
       {!isLoading && labDetails && (
-      <div className="row">
-        <div className="col-12 col-md-7">
-          <LabDetailsCard
-            details={{
-              labProfileName: labDetails.LabProfileName,
-              userFirstName: labDetails.UserFirstName,
-              userLastName: labDetails.UserLastName,
-              startTime: formatTime(labDetails.StartTime),
-              endTime: formatTime(labDetails.EndTime),
-              state: labDetails.State,
-              completionStatus: labDetails.CompletionStatus,
-              totalRunTime: labDetails.TotalRunTime,
-              examPassed: labDetails.exam_passed ? 'Yes' : 'No',
-            }}
-          />
+      <div className="container">
+        <div className="row">
+          <div className="col-12 col-md-7">
+            <LabDetailsCard
+              details={{
+                labProfileName: labDetails.LabProfileName,
+                userFirstName: labDetails.UserFirstName,
+                userLastName: labDetails.UserLastName,
+                startTime: formatTime(labDetails.StartTime),
+                endTime: formatTime(labDetails.EndTime),
+                state: labDetails.State,
+                completionStatus: labDetails.CompletionStatus,
+                totalRunTime: labDetails.TotalRunTime,
+                examPassed: labDetails.exam_passed ? 'Yes' : 'No',
+              }}
+            />
+          </div>
         </div>
-        <div className="col-12 col-md-5">
-          {/* Useful for further features. */}
+        <div className="row">
+          <div className="col-12 col-md-12">
+            <JsonViewer labName={labProfileName} labData={labDetails} />
+          </div>
         </div>
       </div>
       )}

--- a/src/components/Main.scss
+++ b/src/components/Main.scss
@@ -11,7 +11,7 @@
 }
 
 .link-muted {
-    color: #007394 !important;
+    color: $hyperlink-color !important;
     text-decoration: underline;
     font-weight: 700; // This makes the font more similar to the mock up
 }


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-1472

## Description
This PR adds a feature to display the entire JSON response of the /details endpoint in a viewer.

## Changes Made

- [x] Add dependency of the jsoneditor JS library
- [x] Add component JSON viewer to the details view 

## How To Test

Before any prior step, go to your MFE folder and execute `npm i` to install the new dependencies.

Please have your devstack environment running, run `npm start` and the MFE shall be running in port 2003 then, please go to the LMS and access to a skillable ready course, there into the Skillable Tab, the MFe will be shown, access any student of the roster, select one of the given laboratories and the view shall be displayed

![image](https://github.com/user-attachments/assets/1e9dc9ed-c41f-4b9b-a042-c28d34ecf0f2)



