### PR TITLE
PADV-1542 feat: Frontend - Add number of launches at the Lab Summary table

### DIFF
--- a/src/components/LabSummary/columns.jsx
+++ b/src/components/LabSummary/columns.jsx
@@ -29,6 +29,15 @@ const columns = (componentNavigationHandler) => {
       ),
     },
     {
+      Header: (
+        <>
+          Number of <br /> Launches
+        </>
+      ),
+      accessor: 'lab_instances_count',
+      Cell: ({ value }) => value || 1,
+    },
+    {
       Header: 'Score',
       accessor: 'exam_score',
     },

--- a/src/components/LabSummary/index.jsx
+++ b/src/components/LabSummary/index.jsx
@@ -41,6 +41,7 @@ const LabSummary = ({ rosterStudent, componentNavigationHandler }) => {
 
         labsData.push({
           lab_profile_name: laboratory.lab_profile_name,
+          lab_instances_count: laboratory.lab_instances_count,
           lab_instance_id: laboratory.lab_instance_id,
           exam_score: laboratory.exam_score ?? 'N/A',
           exam_percentage: Number.isNaN(examPercentage) ? 'N/A' : `${examPercentage}%` ?? 'N/A',


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-1542

## Description
The objective of these changes was to add the "Number of Launches" column to the Lab Summary table will provide users with valuable insight into how many times each lab has been accessed. This information can help users track engagement and participation, allowing them to better understand their usage patterns and identify labs that require additional attention. 

## Changes Made

- [x] Adds Number of Launches column to Class Roster datatable. 

## How To Test

Before any prior step, go to your MFE folder and execute `npm i` to install the new dependencies.

1. Please have your devstack environment running, run `npm start` and the MFE shall be running in port 2003 
2. go to the LMS and access to a skillable course.
3. Click on Training Lab tab to access the MFe.
4. Navigate to Strudent Roster.
5. Select a student instance.
6. Check that Lab Summary shows the new field.


![image](https://github.com/user-attachments/assets/a5813685-a239-4f9c-9ec4-02f48ad0fd22)


