### PR TITLE
PADV-1519 Make the iframe height dynamic on the instructor tab

### DIFF
--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 import ClassRoster from './ClassRoster';
 import LabSummary from './LabSummary';
@@ -67,6 +67,26 @@ const Main = () => {
     }
     return <ClassRoster componentNavigationHandler={switchComponents} />;
   };
+
+  useEffect(() => {
+    const sendHeight = () => {
+      // Send height to the parent window
+      const height = document.body.scrollHeight;
+      const message = { type: 'iframeHeight', height };
+      const originUrl = window.location.origin;
+      window.parent.postMessage(message, originUrl);
+    };
+
+    const observer = new MutationObserver(() => {
+      sendHeight();
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [showLabDetails, showLabSummary]);
 
   return (
     <div className="main-container">


### PR DESCRIPTION
## Description

This PR make the iframe height dynamic on the instructor tab, at the skillable dashboard. This feature avoids that the parent view appear a double scroll, one in the container of the Skillable MFE and the other one in the tab view.

_Before_:
[Screencast from 23-08-24 15:06:13.webm](https://github.com/user-attachments/assets/7b4fed5c-d9aa-4c0e-8c17-3f924d04b735)

_After_:
[Screencast from 23-08-24 15:11:26.webm](https://github.com/user-attachments/assets/6d4cd0ee-46fe-4016-b30b-6ec26cd26140)

## How to test

Pleae, follow the steps on https://github.com/Pearson-Advance/skillable-plugin/pull/47

## Jira issue

* https://agile-jira.pearson.com/browse/PADV-1519