### PR TITLE
PADV-1500 feat: Check React router implementation

### DIFF
--- a/src/components/ClassRoster/columns.jsx
+++ b/src/components/ClassRoster/columns.jsx
@@ -1,15 +1,17 @@
 import React from 'react';
 import { Hyperlink } from '@edx/paragon';
+import { mfeBaseUrl } from '../../constants';
 
-const columns = (componentNavigationHandler) => {
+const columns = (courseId, setRosterStudent, history) => {
   /**
    * Displays the expected component when there is a click on the cell where this method is called
    *
    * @param {object} row - the given row from fetched data where the content would be accessed
    */
   const handleUsernameClick = (row) => {
-    const student = { user_id: row.original.anonymous_user_id, username: row.original.user };
-    componentNavigationHandler(student);
+    const student = { user_id: row.original.anonymous_user_id, username: row.original.user, courseId };
+    setRosterStudent(student);
+    history.push(`${mfeBaseUrl.replace(':courseId', courseId)}/lab-summary/${student.user_id}`);
   };
 
   return [

--- a/src/components/ClassRoster/index.jsx
+++ b/src/components/ClassRoster/index.jsx
@@ -12,13 +12,12 @@ import { defaultErrorMessage } from '../../constants';
 
 const ENROLLMENTS_URL = `${process.env.LMS_BASE_URL}/pearson-core/api/v1/course-enrollments`;
 
-const ClassRoster = ({ componentNavigationHandler }) => {
+const ClassRoster = ({ courseId, setRosterStudent, history }) => {
   const [users, setUsers] = useState([]);
   const [currentPage, setCurrentPage] = useState(1);
   const [pageCount, setPageCount] = useState(1);
   const [isLoading, setIsLoading] = useState(true);
   const [filterErrorMessage, setFilterErrorMessage] = useState(null);
-  const courseId = window.location.pathname.split('/').filter(Boolean)[1];
 
   /**
   * Consumes course-enrollments API from pearson-core plugin of Devstack
@@ -79,7 +78,7 @@ const ClassRoster = ({ componentNavigationHandler }) => {
       <Table
         isLoading={isLoading}
         data={users}
-        columns={columns(componentNavigationHandler)}
+        columns={columns(courseId, setRosterStudent, history)}
         emptyMessage="No users found."
         pageCount={pageCount}
         currentPage={currentPage}
@@ -90,7 +89,11 @@ const ClassRoster = ({ componentNavigationHandler }) => {
 };
 
 ClassRoster.propTypes = {
-  componentNavigationHandler: PropTypes.func,
+  courseId: PropTypes.string.isRequired,
+  setRosterStudent: PropTypes.func.isRequired,
+  history: PropTypes.shape({
+    push: PropTypes.func.isRequired,
+  }).isRequired,
 };
 
 export default ClassRoster;

--- a/src/components/DashboardLaunchButton/index.jsx
+++ b/src/components/DashboardLaunchButton/index.jsx
@@ -3,13 +3,13 @@ import PropTypes from 'prop-types';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { logError } from '@edx/frontend-platform/logging';
 import { Button } from 'react-paragon-topaz';
-
 import AlertMessage from '../AlertMessage';
-import { SKILLABLE_URL, defaultErrorMessage } from '../../constants';
+import { skillableUrl, defaultErrorMessage } from '../../constants';
 import { eventManager } from '../../helpers';
+
 import './index.scss';
 
-const COURSE_TAB_URL = `${SKILLABLE_URL}/course-tab/api/v1`;
+const COURSE_TAB_URL = `${skillableUrl}/course-tab/api/v1`;
 
 const DashboardLaunchButton = ({ courseId, title }) => {
   const [isButtonVisible, setIsButtonVisible] = useState(false);

--- a/src/components/LabDetailsCard/index.jsx
+++ b/src/components/LabDetailsCard/index.jsx
@@ -85,7 +85,17 @@ LabDetailsCard.defaultProps = {
 };
 
 LabDetailsCard.propTypes = {
-  details: PropTypes.objectOf(PropTypes.string),
+  details: PropTypes.shape({
+    labProfileName: PropTypes.string,
+    userFirstName: PropTypes.string,
+    userLastName: PropTypes.string,
+    startTime: PropTypes.string,
+    endTime: PropTypes.string,
+    state: PropTypes.string,
+    completionStatus: PropTypes.string,
+    totalRunTime: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    examPassed: PropTypes.string,
+  }),
 };
 
 export default LabDetailsCard;

--- a/src/components/LabDetailsChartCard/index.jsx
+++ b/src/components/LabDetailsChartCard/index.jsx
@@ -81,7 +81,12 @@ LabDetailsChartCard.defaultProps = {
 };
 
 LabDetailsChartCard.propTypes = {
-  details: PropTypes.objectOf(PropTypes.string),
+  details: PropTypes.shape({
+    NumTasks: PropTypes.number,
+    NumCompletedTasks: PropTypes.number,
+    ExamMaxPossibleScore: PropTypes.number,
+    ExamScore: PropTypes.number,
+  }),
 };
 
 export default LabDetailsChartCard;

--- a/src/components/LabSummary/columns.jsx
+++ b/src/components/LabSummary/columns.jsx
@@ -1,17 +1,26 @@
 import React from 'react';
 import { Hyperlink } from '@edx/paragon';
+import { mfeBaseUrl } from '../../constants';
 
-const columns = (componentNavigationHandler) => {
+const columns = ({
+  setSelectedLabDetails,
+  rosterStudent,
+  courseId,
+  history,
+}) => {
   /**
    * Displays the expected component when there is a click on the cell where this method is called
    *
    * @param {object} row - the given row from fetched data where the content would be accessed
    */
   const handleLabClick = (row) => {
-    componentNavigationHandler(null, {
+    const labDetails = {
       labInstanceId: row.original.lab_instance_id,
       labProfileName: row.original.lab_profile_name,
-    });
+      user_id: rosterStudent.user_id,
+    };
+    setSelectedLabDetails(labDetails);
+    history.push(`${mfeBaseUrl.replace(':courseId', courseId)}/lab-details/${labDetails.labInstanceId}`);
   };
 
   return [

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -1,72 +1,22 @@
 import React, { useState, useEffect } from 'react';
-
+import {
+  BrowserRouter as Router,
+  Route,
+  Switch,
+  Redirect,
+  useLocation,
+} from 'react-router-dom';
+import PropTypes from 'prop-types';
 import ClassRoster from './ClassRoster';
 import LabSummary from './LabSummary';
 import LabDetails from './LabDetails';
+import { mfeBaseUrl } from '../constants';
 
 import './Main.scss';
 
 const Main = () => {
   const [rosterStudent, setRosterStudent] = useState(null);
-  const [showLabSummary, setShowLabSummary] = useState(false);
-  const [showLabDetails, setShowLabDetails] = useState(false);
-  const [labDetails, setLabDetails] = useState({ labInstanceId: null, labProfileName: '' });
-
-  /**
-   * Switch between components to be rendered,
-   * When an anonymous User Id is passed, means that its Lab Summary is going to be fetched and shown
-   *
-   * @param {object} studentReceived - Object with the select student data
-   * @param {object | null} labDetailsReceived - Object containing labInstanceId and labProfileName (if applicable)
-   */
-  const switchComponents = (studentReceived, labDetailsReceived = null) => {
-    if (studentReceived) {
-      setRosterStudent(studentReceived);
-      setShowLabSummary(true);
-      setShowLabDetails(false);
-      return setShowLabSummary(true);
-    }
-    if (labDetailsReceived) {
-      setLabDetails(labDetailsReceived);
-      setShowLabSummary(false);
-      setShowLabDetails(true);
-      return setShowLabDetails(true);
-    }
-    setShowLabSummary(false);
-    setShowLabDetails(false);
-    return false;
-  };
-
-  /**
-   * Renders the appropriate component based on the current state.
-   * If `showLabDetails` is true, it renders the LabDetails component.
-   * If `showLabSummary` is true, it renders the LabSummary component.
-   * Otherwise, it renders the ClassRoster component.
-   *
-   * @returns {React.Element} The component to be rendered.
-   */
-  const renderComponent = () => {
-    if (showLabDetails) {
-      return (
-        <LabDetails
-          labInstanceId={String(labDetails.labInstanceId)}
-          labProfileName={labDetails.labProfileName}
-          labData={labDetails}
-          rosterStudent={rosterStudent}
-          componentNavigationHandler={switchComponents}
-        />
-      );
-    }
-    if (showLabSummary) {
-      return (
-        <LabSummary
-          rosterStudent={rosterStudent}
-          componentNavigationHandler={switchComponents}
-        />
-      );
-    }
-    return <ClassRoster componentNavigationHandler={switchComponents} />;
-  };
+  const [selectedLabDetails, setSelectedLabDetails] = useState(null);
 
   useEffect(() => {
     const sendHeight = () => {
@@ -86,13 +36,60 @@ const Main = () => {
     return () => {
       observer.disconnect();
     };
-  }, [showLabDetails, showLabSummary]);
+  }, [useLocation()]);
 
   return (
-    <div className="main-container">
-      {renderComponent()}
-    </div>
+    <Router>
+      <div className="main-container">
+        <Switch>
+          <Route
+            exact
+            path={`${mfeBaseUrl}`}
+            render={(props) => (
+              <ClassRoster
+                {...props}
+                courseId={props.match.params.courseId}
+                setRosterStudent={setRosterStudent}
+              />
+            )}
+          />
+          <Route
+            path={`${mfeBaseUrl}/lab-summary/:studentId`}
+            render={(props) => (
+              <LabSummary
+                {...props}
+                courseId={props.match.params.courseId}
+                rosterStudent={rosterStudent}
+                setSelectedLabDetails={setSelectedLabDetails}
+              />
+            )}
+          />
+          <Route
+            path={`${mfeBaseUrl}/lab-details/:labInstanceId`}
+            render={(props) => (
+              <LabDetails
+                {...props}
+                courseId={props.match.params.courseId}
+                labData={selectedLabDetails}
+                rosterStudent={rosterStudent}
+              />
+            )}
+          />
+          <Redirect from="/" to={`${mfeBaseUrl}`} />
+        </Switch>
+      </div>
+    </Router>
   );
+};
+
+Main.propTypes = {
+  match: PropTypes.shape({
+    params: PropTypes.shape({
+      courseId: PropTypes.string.isRequired,
+      studentId: PropTypes.string,
+      labInstanceId: PropTypes.string,
+    }).isRequired,
+  }),
 };
 
 export default Main;

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,2 +1,3 @@
-export const SKILLABLE_URL = `${process.env.LMS_BASE_URL}/skillable_plugin`;
+export const skillableUrl = `${process.env.LMS_BASE_URL}/skillable_plugin`;
 export const defaultErrorMessage = 'An unexpected error occurred. Please try again later.';
+export const mfeBaseUrl = '/skillable-dashboard/:courseId';


### PR DESCRIPTION
## Tickets

- https://agile-jira.pearson.com/browse/PADV-1500

## Description
This update refactors the routing and navigation logic within the application to enhance clarity, maintainability, and modularity. The main goal was to separate routing concerns from state management and component logic, thereby making the application easier to understand and extend.

## Changes Made

- [x] **Introduction of React Router for Navigation:**
  - Implemented React Router to manage the application's navigation logic. This allows for more declarative routing, making the navigation flow clearer and reducing the reliance on manual state manipulation for route changes.
  - Replaced the previous state-driven navigation logic with React Router's declarative routes.

- [x] **Refactor of Component Navigation Logic:**
  - The `Main.jsx` component was refactored to utilize `react-router-dom` for managing routes between `ClassRoster`, `LabSummary`, and `LabDetails`.
  - Simplified the `Main.jsx` logic by removing manual condition checks for component switching and delegating navigation responsibilities to React Router.

- [x] **Dynamic URL Parameter Handling:**
  - Each view now dynamically receives URL parameters (`courseId`, `studentId`, `labInstanceId`) from React Router, allowing components like `LabSummary` and `LabDetails` to correctly display data based on the current route.

- [x] **Enhanced Prop Types and Default Props:**
  - Updated `PropTypes` validation to ensure that all required parameters are properly validated, and adjusted default props to handle cases where certain props might be absent.

## How To Test

1. Ensure your development environment is set up with the latest dependencies by running `npm i` in your MFE folder.
2. Start the MFE by running `npm start` and ensure it is running on port 2003.
3. Access the LMS and navigate to a skillable course.
4. Click on the Training Lab tab to load the MFE.
5. **Test the Routing:**
   - Navigate through the `ClassRoster`, `LabSummary`, and `LabDetails` views using the respective UI elements.
   - Refresh the page on `LabSummary` and `LabDetails` to confirm redirection to `ClassRoster`.


![Peek 2024-08-24 23-15](https://github.com/user-attachments/assets/37c6a8e7-4054-40f5-a846-ac0d64217123)