### PR TITLE
PADV-1614 Collapse the json lab details by default

### DIFF
--- a/src/shared/JsonViewer/index.jsx
+++ b/src/shared/JsonViewer/index.jsx
@@ -24,6 +24,7 @@ const JsonViewer = ({ labName, labData }) => {
     };
     editorRef.current = new JSONEditor(containerRef.current, options);
     editorRef.current.set(labData);
+    editorRef.current.collapseAll();
 
     return () => {
       if (editorRef.current) {


### PR DESCRIPTION
## Description

This PR collapse by default the main Json lab details

![Screenshot 2024-08-27 at 5 16 58 PM](https://github.com/user-attachments/assets/e74601d0-df2c-4817-a394-a4c4decf481d)

## How to test

1. Go to the mfe at ``http://localhost:2003/skillable-dashboard/{course_id}/lab-details/{lab_instance_id}``, you should see something like the image above

2. Go to the instructor tab at ``http://localhost:18000/skillable_plugin/course-tab/courses/{course_id}/training_labs``, and navigate to "Lab Details" interphase, the Json section should be collapse

## Jira issue

* https://agile-jira.pearson.com/browse/PADV-1614