### PR TITLE
PADV-1758 fix: make LabDetailsCard and LabDetailsChartCard height equal

### DIFF
--- a/src/shared/DashboardLaunchButton/index.scss
+++ b/src/shared/DashboardLaunchButton/index.scss
@@ -1,20 +1,20 @@
 .dashboard-launch-container {
-    margin-left: 10px;
-    margin-top: 20px;
-  }
+  margin-left: 10px;
+  margin-top: 20px;
+}
 
-  .main-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-top: 30px;
-  }
+.main-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 30px;
+}
 
-  .instructor-dashboard-button {
-    margin-left: auto;
-    margin-right: 10px;
-  }
+.instructor-dashboard-button {
+  margin-left: auto;
+  margin-right: 10px;
+}
 
-  .error-container {
-    margin-top: 20px;
-  }
+.error-container {
+  margin-top: 20px;
+}

--- a/src/shared/LabDetailsCard/index.scss
+++ b/src/shared/LabDetailsCard/index.scss
@@ -1,47 +1,47 @@
 .lab-details-card {
-    width: 100%;
-    margin-left: 10px;
-    margin-top: 20px;
-  }
+  width: 100%;
+  margin-left: 10px;
+  margin-top: 20px;
+}
 
-  .lab-details {
-    display: flex;
-    flex-direction: column;
-    padding: 20px 0px 20px 20px;
-  }
+.lab-details {
+  display: flex;
+  flex-direction: column;
+  padding: 20px 0px 20px 20px;
+}
 
+.lab-details-row {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.lab-details-item {
+  flex: 1;
+  padding: 10px;
+}
+
+.lab-details-item strong {
+  display: block;
+  font-size: 12px;
+  color: #666;
+  font-weight: lighter;
+}
+
+.lab-details-item span {
+  display: block;
+  font-size: 16px;
+  color: #000;
+  font-weight: bold;
+}
+
+@media (max-width: 768px) {
   .lab-details-row {
-    display: flex;
-    justify-content: space-between;
-    margin-bottom: 10px;
+    flex-wrap: wrap;
   }
 
   .lab-details-item {
-    flex: 1;
-    padding: 10px;
+    flex: 0 0 50%;
+    padding: 10px 0;
   }
-
-  .lab-details-item strong {
-    display: block;
-    font-size: 12px;
-    color: #666;
-    font-weight: lighter;
-  }
-
-  .lab-details-item span {
-    display: block;
-    font-size: 16px;
-    color: #000;
-    font-weight: bold;
-  }
-
-  @media (max-width: 768px) {
-    .lab-details-row {
-      flex-wrap: wrap;
-    }
-
-    .lab-details-item {
-      flex: 0 0 50%;
-      padding: 10px 0;
-    }
-  }
+}

--- a/src/views/LabDetails/index.scss
+++ b/src/views/LabDetails/index.scss
@@ -1,8 +1,31 @@
 /* LabDetails.scss */
 
 .spinner-container {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    height: 80vh;
-  }
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 80vh;
+}
+
+.row {
+  display: flex;
+  align-items: stretch;
+}
+
+.col-12.col-md-7,
+.col-12.col-md-5 {
+  display: flex;
+  flex-direction: column;
+}
+
+.lab-details-card,
+.lab-details-chard-card {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.lab-details-card .card,
+.lab-details-chard-card .card {
+  height: 100%;
+}


### PR DESCRIPTION
## Description

This PR fix the style to the LabDetailsCard and LabDetailsChartCard containers to have the same height.

### Before

![Screenshot from 2024-12-23 14-44-01](https://github.com/user-attachments/assets/343a040b-27af-44ca-b26c-946740e74da6)


### After

![Screenshot from 2024-12-23 14-43-21](https://github.com/user-attachments/assets/8e630e8e-05f0-4b38-9a43-38ed2ad0104a)

## How to test

Please, go to a Course or CCX Course to the instructor tab and retrieve the lab information, clicking on ``Class Roster / Lab Summary / Lab Details`` path. Try to inspect the first container and modifies, (for example, LAB PROFILE NAME to the content be very long), and see how the height changes equally.

## Jira issue

* https://agile-jira.pearson.com/browse/PADV-1758