### PR TITLE
PADV-2142 feat: use students endpoint of course operation for ccx clases

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -17,3 +17,4 @@ SITE_NAME=localhost
 USER_INFO_COOKIE_NAME='edx-user-info'
 MFE_CONFIG_API_URL='http://localhost:18000/api/mfe_config/v1'
 SKILLABLE_PATH='skillable-dashboard'
+COURSE_OPERATIONS_API_V2_BASE_URL='http://localhost:18000/pearson_course_operation/api/v2'

--- a/src/views/ClassRoster/columns.jsx
+++ b/src/views/ClassRoster/columns.jsx
@@ -10,7 +10,7 @@ const columns = (courseId, setRosterStudent, history) => {
    * @param {object} row - the given row from fetched data where the content would be accessed
    */
   const handleUsernameClick = (row) => {
-    const student = { user_id: row.original.anonymous_user_id, username: row.original.user, courseId };
+    const student = { user_id: row.original.learner_anonymous_id, username: row.original.learner_name, courseId };
     setRosterStudent(student);
     history.push(`${mfeBaseUrl.replace(':courseId', courseId)}/lab-summary/${student.user_id}`);
   };
@@ -18,20 +18,20 @@ const columns = (courseId, setRosterStudent, history) => {
   return [
     {
       Header: 'Username',
-      accessor: 'user',
+      accessor: 'learner_name',
       /* eslint-disable react/prop-types */
       Cell: ({ row }) => (
         <Hyperlink
           destination="#"
           onClick={() => handleUsernameClick(row)}
         >
-          {row.original.user}
+          {row.original.learner_name}
         </Hyperlink>
       ),
     },
     {
       Header: 'Email',
-      accessor: 'email',
+      accessor: 'learner_email',
     },
   ];
 };

--- a/src/views/ClassRoster/tests/columns.test.jsx
+++ b/src/views/ClassRoster/tests/columns.test.jsx
@@ -25,16 +25,16 @@ describe('Columns Component', () => {
   it('renders columns correctly', () => {
     expect(columnDefinitions[0].Header).toBe('Username');
     expect(columnDefinitions[1].Header).toBe('Email');
-    expect(columnDefinitions[0].accessor).toBe('user');
-    expect(columnDefinitions[1].accessor).toBe('email');
+    expect(columnDefinitions[0].accessor).toBe('learner_name');
+    expect(columnDefinitions[1].accessor).toBe('learner_email');
   });
 
   it('renders a hyperlink and calls handleUsernameClick on click', () => {
     const mockRow = {
       original: {
-        user: 'testuser',
-        email: 'testuser@example.com',
-        anonymous_user_id: 'anon_id_123',
+        learner_name: 'testuser',
+        learner_email: 'testuser@example.com',
+        learner_anonymous_id: 'anon_id_123',
       },
     };
 

--- a/src/views/ClassRoster/tests/index.test.jsx
+++ b/src/views/ClassRoster/tests/index.test.jsx
@@ -22,6 +22,12 @@ jest.mock('@edx/frontend-platform/auth', () => ({
   })),
 }));
 
+jest.mock('@edx/frontend-platform', () => ({
+  getConfig: jest.fn().mockReturnValue({
+    COURSE_OPERATIONS_API_V2_BASE_URL: 'http://localhost:18000/pearson_course_operation/api/v1',
+  }),
+}));
+
 jest.mock('@edx/frontend-platform/logging', () => ({
   logError: jest.fn(),
 }));


### PR DESCRIPTION
## Description

This PR modify the endpoints used to populate the Class Roster table where are all the students enrolled in a class o course. The idea is to use the same endpoint that use CPM/IP (/students endpoint defined in [course operation repo](https://github.com/Pearson-Advance/course_operations/blob/master/pearson_course_operation/api/v2/institution_admin/views.py#L102)), but this endpoint return only the students that are enrolled in a class. So we need to continue using the ``/pearson-core/api/v1/course-enrollments`` endpoint to the cases where a master course is using.

## how to test

1. Use this branch ``vue/PADV-2142`` and the branch [vue/PADV-2142](https://github.com/Pearson-Advance/pearson-core/pull/64) in your local environment
2. Go to a class list in CPM and go into a class to see the student list http://localhost:1980/institution-portal/courses
3. To compare the students list, go to a **CCX class**, in the **training lab** tab http://localhost:18000/skillable_plugin/course-tab/courses/{ccx_id}/training_labs, the **_ccx_id_** have to be the same that see in the step 2.
4. Compare the list, it has to be equal en both cases (step 2 and step 3)
5. To test the functionality for a **master course**, please go into the **Training Lab** tab from a **master course**

## Example to:

### Compare the students endpoint for CCX class

* Training Lab
![image](https://github.com/user-attachments/assets/b3e50ee9-ce0c-4b27-a628-3861a56a8906)
* CertPREP Manager
![image](https://github.com/user-attachments/assets/ba0c4588-4247-4e93-822e-15fdbd7b0868)

### See the course-enrollments request for a master course
* Training Lab
![image](https://github.com/user-attachments/assets/81e76ac5-01c3-48d1-a86e-3726aea37159)
* CertPREP Manager

**Not Possible to Master courses**

## Jira issue

* https://agile-jira.pearson.com/browse/PADV-2142