### PR TITLE
PADV-2166 fix: change the email and name filter fields to work correctly

### DIFF
--- a/src/shared/TableFilter/index.jsx
+++ b/src/shared/TableFilter/index.jsx
@@ -10,7 +10,7 @@ import { Search } from '@edx/paragon/icons';
 
 const TableFilter = ({ onFilterSubmit, error }) => {
   const [filterValue, setFilterValue] = useState('');
-  const [selectedParam, setSelectedParam] = useState('username');
+  const [selectedParam, setSelectedParam] = useState('learner_name');
   const [filterErrorMessage, setFilterErrorMessage] = useState(null);
 
   const handleFilterChange = (e) => setFilterValue(e.target.value);
@@ -54,8 +54,8 @@ const TableFilter = ({ onFilterSubmit, error }) => {
       <Form.Group as={Col} controlId="formGridParam">
         <Form.RadioSet name="selectedParam" onChange={handleParamChange} value={selectedParam}>
           <div className="radio-buttons">
-            <Form.Radio value="username" className="form-radio">username</Form.Radio>
-            <Form.Radio value="email" className="form-radio">email</Form.Radio>
+            <Form.Radio value="learner_name" className="form-radio">Name</Form.Radio>
+            <Form.Radio value="learner_email" className="form-radio">Email</Form.Radio>
           </div>
         </Form.RadioSet>
       </Form.Group>

--- a/src/shared/TableFilter/tests/index.test.jsx
+++ b/src/shared/TableFilter/tests/index.test.jsx
@@ -14,8 +14,8 @@ describe('TableFilter Component', () => {
     render(<TableFilter onFilterSubmit={mockOnFilterSubmit} />);
 
     expect(screen.getByPlaceholderText('Search student')).toBeInTheDocument();
-    expect(screen.getByText('username')).toBeInTheDocument();
-    expect(screen.getByText('email')).toBeInTheDocument();
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Email')).toBeInTheDocument();
     expect(screen.getByText('Apply')).toBeDisabled();
     expect(screen.getByText('Reset')).toBeInTheDocument();
   });
@@ -38,7 +38,7 @@ describe('TableFilter Component', () => {
     fireEvent.change(input, { target: { value: 'john' } });
     fireEvent.click(submitButton);
 
-    expect(mockOnFilterSubmit).toHaveBeenCalledWith({ username: 'john' });
+    expect(mockOnFilterSubmit).toHaveBeenCalledWith({ learner_name: 'john' });
   });
 
   it('resets the filter value and error message when the reset button is clicked', () => {
@@ -63,7 +63,7 @@ describe('TableFilter Component', () => {
 
   it('changes the selected parameter correctly', () => {
     render(<TableFilter onFilterSubmit={mockOnFilterSubmit} />);
-    const emailRadio = screen.getByLabelText('email');
+    const emailRadio = screen.getByLabelText('Email');
 
     fireEvent.click(emailRadio);
     const input = screen.getByPlaceholderText('Search student');
@@ -72,6 +72,6 @@ describe('TableFilter Component', () => {
     const submitButton = screen.getByText('Apply');
     fireEvent.click(submitButton);
 
-    expect(mockOnFilterSubmit).toHaveBeenCalledWith({ email: 'john@example.com' });
+    expect(mockOnFilterSubmit).toHaveBeenCalledWith({ learner_email: 'john@example.com' });
   });
 });

--- a/src/views/ClassRoster/columns.jsx
+++ b/src/views/ClassRoster/columns.jsx
@@ -17,7 +17,7 @@ const columns = (courseId, setRosterStudent, history) => {
 
   return [
     {
-      Header: 'Username',
+      Header: 'Name',
       accessor: 'learner_name',
       /* eslint-disable react/prop-types */
       Cell: ({ row }) => (

--- a/src/views/ClassRoster/tests/columns.test.jsx
+++ b/src/views/ClassRoster/tests/columns.test.jsx
@@ -23,7 +23,7 @@ describe('Columns Component', () => {
   const columnDefinitions = columns(mockCourseId, mockSetRosterStudent, mockHistory);
 
   it('renders columns correctly', () => {
-    expect(columnDefinitions[0].Header).toBe('Username');
+    expect(columnDefinitions[0].Header).toBe('Name');
     expect(columnDefinitions[1].Header).toBe('Email');
     expect(columnDefinitions[0].accessor).toBe('learner_name');
     expect(columnDefinitions[1].accessor).toBe('learner_email');


### PR DESCRIPTION
## Description

This PR update the field to filter by email or name correctly in the Lab Summary, in the Class Roster table

## How to test

1. Use this branch ``vue/PADV-2166`` and the branch [vue/PADV-2166](https://github.com/Pearson-Advance/pearson-core/pull/66) in your local environment
2. Go to a **CCX class**, in the **training lab** tab http://localhost:18000/skillable_plugin/course-tab/courses/{ccx_id}/training_labs.
3. Test the filters, using by name or email

## Jira issue

* https://agile-jira.pearson.com/browse/PADV-2166