### PR TITLE
PADV-1901 chore: hide the Class Roster Table and the filter

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -29,4 +29,5 @@ subscribe(APP_INIT_ERROR, (error) => {
 
 initialize({
   messages: [],
+  requireAuthenticatedUser: true,
 });

--- a/src/views/ClassRoster/index.jsx
+++ b/src/views/ClassRoster/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-vars */
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
@@ -5,10 +6,7 @@ import { getConfig } from '@edx/frontend-platform';
 import { logError } from '@edx/frontend-platform/logging';
 
 import DashboardLaunchButton from 'shared/DashboardLaunchButton';
-import TableFilter from 'shared/TableFilter';
-import Table from 'shared/Table';
 import { defaultErrorMessage } from 'constants';
-import { columns } from './columns';
 
 import './index.scss';
 
@@ -77,30 +75,13 @@ const ClassRoster = ({ courseId, setRosterStudent, history }) => {
    *                          (e.g., 'username' or 'email') and the value is
    *                          the user's input.
    */
-  const handleFilterSubmit = (filter) => {
-    setFilterErrorMessage(null);
-    fetchUsersData(filter);
-  };
-
   useEffect(() => {
     fetchUsersData();
   }, [currentPage]);
 
   return (
     <div>
-      <DashboardLaunchButton courseId={courseId} title="Class Roster" />
-      <div className="filterWrapper">
-        <TableFilter onFilterSubmit={handleFilterSubmit} error={filterErrorMessage} />
-      </div>
-      <Table
-        isLoading={isLoading}
-        data={users}
-        columns={columns(courseId, setRosterStudent, history)}
-        emptyMessage="No users found."
-        pageCount={pageCount}
-        currentPage={currentPage}
-        handlePagination={setCurrentPage}
-      />
+      <DashboardLaunchButton courseId={courseId} title="Instructor Launch" />
     </div>
   );
 };

--- a/src/views/ClassRoster/tests/index.test.jsx
+++ b/src/views/ClassRoster/tests/index.test.jsx
@@ -2,12 +2,10 @@ import React from 'react';
 import {
   render,
   screen,
-  fireEvent,
   waitFor,
   act,
 } from '@testing-library/react';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
-import { logError } from '@edx/frontend-platform/logging';
 import ClassRoster from '../index';
 import '@testing-library/jest-dom';
 
@@ -59,7 +57,6 @@ describe('ClassRoster Component', () => {
       );
     });
 
-    expect(screen.getByText('Mocked Table Component')).toBeInTheDocument();
     expect(screen.getByText('Mocked DashboardLaunchButton')).toBeInTheDocument();
   });
 
@@ -70,61 +67,6 @@ describe('ClassRoster Component', () => {
       expect(getAuthenticatedHttpClient().post).toHaveBeenCalledWith(
         'undefined/pearson-core/api/v1/course-enrollments?page=1',
         { course_id: 'course-v1:edX+DemoX+Demo_Course' },
-      );
-    });
-  });
-
-  it('handles filter submission', async () => {
-    await act(async () => {
-      render(
-        <ClassRoster
-          courseId={mockCourseId}
-          setRosterStudent={mockSetRosterStudent}
-          history={mockHistory}
-        />,
-      );
-    });
-
-    const filterButton = screen.getByRole('button', { name: /Apply/i });
-    act(() => {
-      fireEvent.click(filterButton);
-    });
-
-    expect(mockSetRosterStudent).not.toHaveBeenCalled();
-  });
-
-  it('handles error during data fetch', async () => {
-    mockPost.mockRejectedValueOnce({
-      response: {
-        data: {
-          email: ['Invalid email format'],
-        },
-      },
-    });
-
-    render(<ClassRoster courseId={mockCourseId} setRosterStudent={mockSetRosterStudent} history={mockHistory} />);
-
-    await waitFor(() => {
-      expect(logError).toHaveBeenCalled();
-      expect(screen.getByText('Invalid email format')).toBeInTheDocument();
-    });
-  });
-  it('resets error message and calls fetchUsersData on filter submission', async () => {
-    getAuthenticatedHttpClient.mockReturnValue({ post: mockPost });
-    render(
-      <ClassRoster
-        courseId={mockCourseId}
-        setRosterStudent={mockSetRosterStudent}
-        history={mockHistory}
-      />,
-    );
-    const filterButton = screen.getByRole('button', { name: /Apply/i });
-    fireEvent.click(filterButton);
-    expect(screen.queryByText('Error message')).not.toBeInTheDocument();
-    await waitFor(() => {
-      expect(mockPost).toHaveBeenCalledWith(
-        expect.stringContaining('/pearson-core/api/v1/course-enrollments'),
-        expect.any(Object),
       );
     });
   });


### PR DESCRIPTION
## Description

The principal objective of this PR is to hide the Class Roster table and the filter that appear in the initial view of the Skillable MFE. So the lines that affect this are:

``` jsx
      <div className="filterWrapper">
        <TableFilter onFilterSubmit={handleFilterSubmit} error={filterErrorMessage} />
      </div>
      <Table
        isLoading={isLoading}
        data={users}
        columns={columns(courseId, setRosterStudent, history)}
        emptyMessage="No users found."
        pageCount={pageCount}
        currentPage={currentPage}
        handlePagination={setCurrentPage}
      />
```

It isn't deprecate as complete, because in the future we'll use and refactor par of the actual design. So the necessity now is just to show the “instructor dashboard button”.

## How to test

1. Go to a CCX course, on the "Training Lab" tab and see the Instructor Launch Button
![image](https://github.com/user-attachments/assets/5219b535-937c-4d5e-8603-c7210161244f)

2. Go to http://{lms_base}/skillable-dashboard/{ccx_id}
![image](https://github.com/user-attachments/assets/fe79c57b-51fe-492b-bfd7-69b686e462ae)

## Jira issue

* https://agile-jira.pearson.com/browse/PADV-1901
